### PR TITLE
[ FEAT ] 컨테이너 기본 구성 도입

### DIFF
--- a/app/containers/domain.py
+++ b/app/containers/domain.py
@@ -1,0 +1,4 @@
+from dependency_injector import containers, providers
+
+class DomainsContainer(containers.DeclarativeContainer):
+    infra = providers.DependenciesContainer()

--- a/app/containers/infra.py
+++ b/app/containers/infra.py
@@ -1,7 +1,11 @@
 from dependency_injector import containers, providers
 
 from app.core.config import settings
+from app.database.session import AsyncScopedSession
 
 
 class InfraContainer(containers.DeclarativeContainer):
     config = providers.Object(settings)
+
+    # DB 세션 
+    session = providers.Object(AsyncScopedSession)

--- a/app/containers/infra.py
+++ b/app/containers/infra.py
@@ -1,0 +1,7 @@
+from dependency_injector import containers, providers
+
+from app.core.config import settings
+
+
+class InfraContainer(containers.DeclarativeContainer):
+    config = providers.Object(settings)

--- a/app/containers/main.py
+++ b/app/containers/main.py
@@ -5,7 +5,11 @@ from app.containers.domain import DomainsContainer
 
 
 class MainContainer(DeclarativeContainer):
-    wiring_config = WiringConfiguration(packages=[])
+    wiring_config = WiringConfiguration(
+        packages=[
+            "app.core.fastapi",
+        ]
+    )
 
     infra = providers.Container(InfraContainer)
     domains = providers.Container(DomainsContainer, infra=infra)

--- a/app/containers/main.py
+++ b/app/containers/main.py
@@ -1,0 +1,11 @@
+from dependency_injector.containers import DeclarativeContainer, WiringConfiguration
+from dependency_injector import providers
+from app.containers.infra import InfraContainer
+from app.containers.domain import DomainsContainer
+
+
+class MainContainer(DeclarativeContainer):
+    wiring_config = WiringConfiguration(packages=[])
+
+    infra = providers.Container(InfraContainer)
+    domains = providers.Container(DomainsContainer, infra=infra)

--- a/app/core/fastapi/middleware.py
+++ b/app/core/fastapi/middleware.py
@@ -1,0 +1,22 @@
+from starlette.types import ASGIApp, Scope, Receive, Send
+from dependency_injector.wiring import inject, Provide
+from sqlalchemy.ext.asyncio import async_scoped_session
+
+
+class AsyncSessionMiddleware:
+    def __init__(self, app: ASGIApp):
+        self.app = app
+
+    @inject
+    def _get_session(
+        self,
+        session: async_scoped_session = Provide["infra.session"],
+    ):
+        return session  
+        
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        session = self._get_session()
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            await session.remove()

--- a/app/core/fastapi/transaction.py
+++ b/app/core/fastapi/transaction.py
@@ -1,0 +1,31 @@
+from functools import wraps
+from dependency_injector.wiring import inject, Provide
+from sqlalchemy.ext.asyncio import async_scoped_session
+
+class transactional:
+    def __init__(self, commit: bool = False):
+        self.commit = commit
+
+    @inject
+    def _get_session(
+        self,
+        session: async_scoped_session = Provide["infra.session"],
+    ):
+        return session 
+
+    def __call__(self, func):
+        @wraps(func)
+        async def _wrapped(*args, **kwargs):
+            session = self._get_session()
+            try:
+                result = await func(*args, **kwargs)
+            except Exception as e:
+                await session.rollback()
+                raise e
+            else:
+                if self.commit:
+                    await session.commit()
+            
+            return result
+
+        return _wrapped

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,49 @@
+from contextlib import asynccontextmanager
+from fastapi import FastAPI, HTTPException, Request, status
+from sqlalchemy import text
+
+from app.containers.main import MainContainer
+from app.core.fastapi.middleware import AsyncSessionMiddleware
+from app.database.session import async_engine
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    yield
+    await async_engine.dispose()
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(
+        title="채채봇",
+        description="채채봇 API 입니다.",
+        version="1.0.0",
+        lifespan=lifespan,
+    )
+
+    container = MainContainer()
+    app.container = container
+
+    app.add_middleware(AsyncSessionMiddleware)          
+
+    @app.get("/health", status_code=status.HTTP_200_OK, summary="Health check")
+    async def health_check(request: Request):
+        infra = request.app.container.infra()
+
+        db = infra.session()
+        try:
+            await db.execute(text("SELECT 1"))
+            return {"status": "ok", "db": "ok"}
+        except Exception as e:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={"status": "fail", "db": "fail", "error": str(e)},
+            )
+        finally:
+            await db.close()
+            
+
+    return app
+
+
+app = create_app()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #1 

## 📝 Description

- **InfraContainer**  
  - 외부 클라이언트 등의 의존성을 **제공**합니다.  
  - 예) `settings`, DB 세션, **S3**, **Redis**, 메시지큐 등 공용 유틸을 여기서 **주입**합니다.

- **DomainsContainer**  
  - 도메인 레이어(레포지토리/서비스 등)를 **조립**합니다.  
  - Infra에서 제공한 의존성(DB 세션, S3, Redis 등)을 받아 도메인별 객체를 **연결**합니다.

- **MainContainer**  
  - Infra와 Domains를 **합쳐 애플리케이션에 연결**합니다.  
  - FastAPI 라우터/미들웨어 등 **wiring 대상 패키지**를 지정해 의존성 주입이 동작하도록 합니다.
