### PR TITLE
[ FEAT ] 고급 검색기 구현 

### DIFF
--- a/notebooks/qa_testset.ipynb
+++ b/notebooks/qa_testset.ipynb
@@ -1277,6 +1277,51 @@
    "source": [
     "df_evaluation"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85fa896a",
+   "metadata": {},
+   "source": [
+    "## `(2) Multy Query, Multy Query Custom, Multi Query Decompostion 평가지표 생성`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af9c8ace",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 평가지표 계산\n",
+    "from krag.utils import evaluate_retrieval_at_K\n",
+    "\n",
+    "retrievers = {\n",
+    "    'multy_query' : multi_query_retriever,\n",
+    "    'multy_query_custom' : multi_query_custom_retriever,\n",
+    "    'multi_query_decompostion' : multi_query_decompostion_retriever,\n",
+    "}\n",
+    "\n",
+    "print(\"k:\", similarity_retriever.search_kwargs)\n",
+    "\n",
+    "df_evaluation, df_evaluation_data = evaluate_retrieval_at_K(\n",
+    "    df_qa_test, \n",
+    "    k=similarity_retriever.search_kwargs['k'],  \n",
+    "    retrievers=retrievers, \n",
+    "    ensemble=False, \n",
+    "    rouge_method='rouge2', \n",
+    "    threshold=0.8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0a86578",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_evaluation"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/qa_testset.ipynb
+++ b/notebooks/qa_testset.ipynb
@@ -817,6 +817,414 @@
     "df_qa_test = pd.read_excel(\"./data/qa_testset.xlsx\")\n",
     "df_qa_test.head(20)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e71de245",
+   "metadata": {},
+   "source": [
+    "# 2. 검색기 구현"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cb50d83d",
+   "metadata": {},
+   "source": [
+    "## `(1) LLM 정의 및 벡터저장소 로드`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "5ba77e60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_ollama import ChatOllama\n",
+    "\n",
+    "llm = ChatOllama(\n",
+    "    model=\"exaone3.5\",\n",
+    "    temperature=0.7,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "bff1a3c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_chroma import Chroma\n",
+    "\n",
+    "vectorstore = Chroma(\n",
+    "    embedding_function=embeddings_model,\n",
+    "    collection_name=\"db_huggingface\",\n",
+    "    persist_directory=\"./chroma\",\n",
+    "    collection_metadata={\"hnsw:space\": \"cosine\"},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f8ab227",
+   "metadata": {},
+   "source": [
+    "## `(2) BM25 Retriever`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "48cb0a63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from krag.tokenizers import KiwiTokenizer\n",
+    "from krag.retrievers import KiWiBM25RetrieverWithScore\n",
+    "\n",
+    "kiwi_tokenizer = KiwiTokenizer(model_type='knlm', typos='basic')\n",
+    "\n",
+    "bm25_retriever = KiWiBM25RetrieverWithScore(\n",
+    "    documents=chunks,\n",
+    "    kiwi_tokenizer=kiwi_tokenizer, \n",
+    "    k=8,\n",
+    "    threshold=0.0,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc759f64",
+   "metadata": {},
+   "source": [
+    "## `(3) Similarity Retriever`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "820490c6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "similarity_retriever = vectorstore.as_retriever(\n",
+    "    search_type=\"similarity_score_threshold\",\n",
+    "    search_kwargs={\"score_threshold\": 0.0, \"k\": 8},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f8177ea",
+   "metadata": {},
+   "source": [
+    "## `(4) Ensemble Retriever`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "8fccf00f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.retrievers import EnsembleRetriever\n",
+    "\n",
+    "ensemble_retrievers = [similarity_retriever, bm25_retriever]\n",
+    "ensemble_retriever = EnsembleRetriever(\n",
+    "    retrievers=ensemble_retrievers, \n",
+    "    weights=[0.5, 0.5]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31329078",
+   "metadata": {},
+   "source": [
+    "## `(5) Multi Query Retriever`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "df1ec77a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.retrievers.multi_query import MultiQueryRetriever\n",
+    "\n",
+    "multiquery_chroma_retriever = vectorstore.as_retriever(\n",
+    "    search_type=\"similarity_score_threshold\",\n",
+    "    search_kwargs={\"score_threshold\": 0.0, \"k\": 8},\n",
+    ")\n",
+    "\n",
+    "multi_query_retriever = MultiQueryRetriever.from_llm(\n",
+    "    retriever=multiquery_chroma_retriever, llm=llm\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b58e1b5a",
+   "metadata": {},
+   "source": [
+    "## `(6) Multi Query Custom Retriever`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "99324601",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import List\n",
+    "\n",
+    "from langchain_core.output_parsers import BaseOutputParser\n",
+    "from langchain_core.prompts import PromptTemplate\n",
+    "\n",
+    "\n",
+    "# 출력 파서: LLM 결과를 질문 리스트로 변환\n",
+    "class LineListOutputParser(BaseOutputParser[List[str]]):\n",
+    "    \"\"\"Output parser for a list of lines.\"\"\"\n",
+    "\n",
+    "    def parse(self, text: str) -> List[str]:\n",
+    "        \"\"\"Split the text into lines and remove empty lines.\"\"\"\n",
+    "        return [line.strip() for line in text.strip().split(\"\\n\") if line.strip()]\n",
+    "\n",
+    "\n",
+    "# 쿼리 생성 프롬프트\n",
+    "QUERY_PROMPT = PromptTemplate(\n",
+    "    input_variables=[\"question\"],\n",
+    "    template=\"\"\"Generate three different versions of the given user question to retrieve relevant documents from a vector database. The goal is to reframe the question from various perspectives to overcome limitations of distance-based similarity search.\n",
+    "\n",
+    "    The generated questions should have the following characteristics:\n",
+    "    1. Maintain the core intent of the original question but use different expressions or viewpoints.\n",
+    "    2. Include synonyms or related concepts where possible.\n",
+    "    3. Slightly broaden or narrow the scope of the question to potentially include diverse relevant information.\n",
+    "\n",
+    "    Write each question on a new line and include only the questions.\n",
+    "\n",
+    "    [Original question]\n",
+    "    {question}\n",
+    "    \n",
+    "    [Alternative questions]\n",
+    "    \"\"\",\n",
+    ")\n",
+    "\n",
+    "# 멀티쿼리 체인 구성\n",
+    "multiquery_chain = QUERY_PROMPT | llm | LineListOutputParser()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74cf97f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multi_query_custom_retriever = MultiQueryRetriever(\n",
+    "    retriever=multiquery_chroma_retriever, \n",
+    "    llm_chain=multiquery_chain, # 멀티쿼리 체인\n",
+    "    parser_key=\"lines\"            \n",
+    ")  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "423a86ba",
+   "metadata": {},
+   "source": [
+    "## `(7) Multi Query Decompostion Retriever`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "d01bb3fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.prompts import PromptTemplate\n",
+    "\n",
+    "QUERY_PROMPT = PromptTemplate(\n",
+    "    input_variables=[\"question\"],\n",
+    "    template=\"\"\"You are an AI language model assistant. Your task is to decompose the given input question into multiple sub-questions. \n",
+    "    The goal is to break down the input into a set of sub-problems/sub-questions that can be answered independently.\n",
+    "\n",
+    "    Follow these guidelines to generate the sub-questions:\n",
+    "    1. Cover various aspects related to the core topic of the original question.\n",
+    "    2. Each sub-question should be specific, clear, and answerable independently.\n",
+    "    3. Ensure that the sub-questions collectively address all important aspects of the original question.\n",
+    "    4. Consider temporal aspects (past, present, future) where applicable.\n",
+    "    5. Formulate the questions in a direct and concise manner.\n",
+    "\n",
+    "    [Input question] \n",
+    "    {question}\n",
+    "\n",
+    "    [Sub-questions (5)]\n",
+    "    \"\"\",\n",
+    ")\n",
+    "\n",
+    "# 쿼리 생성 체인\n",
+    "decomposition_chain = QUERY_PROMPT | llm | LineListOutputParser()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "41e6c8e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 다중 쿼리 검색기 생성\n",
+    "multi_query_decompostion_retriever = MultiQueryRetriever(\n",
+    "    retriever=multiquery_chroma_retriever,    \n",
+    "    llm_chain=decomposition_chain,   # 서브 질문 생성 체인\n",
+    "    parser_key=\"lines\"               \n",
+    ")  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ea8d02c",
+   "metadata": {},
+   "source": [
+    "## `(8) Cross Encoder Reranker Retriever`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "e4418550",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.retrievers.document_compressors import CrossEncoderReranker\n",
+    "from langchain_community.cross_encoders import HuggingFaceCrossEncoder\n",
+    "\n",
+    "model = HuggingFaceCrossEncoder(model_name=\"BAAI/bge-reranker-v2-m3\")\n",
+    "re_ranker = CrossEncoderReranker(model=model, top_n=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "c0d564ae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.retrievers import ContextualCompressionRetriever\n",
+    "\n",
+    "cross_encoder_reranker_retriever = ContextualCompressionRetriever(\n",
+    "    base_compressor=re_ranker, \n",
+    "    base_retriever=multi_query_custom_retriever,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f61891c",
+   "metadata": {},
+   "source": [
+    "## `(9) Embed Filter Compression Retriever`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "e8eeb3c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.retrievers.document_compressors import EmbeddingsFilter\n",
+    "\n",
+    "embeddings_filter = EmbeddingsFilter(embeddings=embeddings_model, similarity_threshold=0.5)\n",
+    "\n",
+    "embed_filter_compression_retriever = ContextualCompressionRetriever(\n",
+    "    base_compressor=embeddings_filter,                            \n",
+    "    base_retriever=cross_encoder_reranker_retriever,              \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d7af5c1",
+   "metadata": {},
+   "source": [
+    "## `(10) Compression Rerank Retriever`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "3b4e5723",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.retrievers.document_compressors import DocumentCompressorPipeline\n",
+    "from langchain_community.document_transformers import EmbeddingsRedundantFilter\n",
+    "\n",
+    "# 중복 문서 제거\n",
+    "redundant_filter = EmbeddingsRedundantFilter(embeddings=embeddings_model)\n",
+    "\n",
+    "# 쿼리와 관련성이 높은 문서만 필터링\n",
+    "relevant_filter = EmbeddingsFilter(\n",
+    "    embeddings=embeddings_model, similarity_threshold=0.5\n",
+    ")\n",
+    "\n",
+    "# Re-ranking\n",
+    "re_ranker = CrossEncoderReranker(model=model, top_n=3)\n",
+    "\n",
+    "pipeline_compressor = DocumentCompressorPipeline(\n",
+    "    transformers=[redundant_filter, relevant_filter, re_ranker]\n",
+    ")\n",
+    "\n",
+    "pipeline_compression_retriever = ContextualCompressionRetriever(\n",
+    "    base_compressor=pipeline_compressor,\n",
+    "    base_retriever=multi_query_custom_retriever,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "530a9ff6",
+   "metadata": {},
+   "source": [
+    "## `(11) Compression LLM-Rerank Retriever`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76bc328d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.retrievers.document_compressors import LLMListwiseRerank\n",
+    "\n",
+    "# 중복 문서 제거\n",
+    "redundant_filter = EmbeddingsRedundantFilter(embeddings=embeddings_model)\n",
+    "\n",
+    "# 쿼리와 관련성이 높은 문서만 필터링\n",
+    "relevant_filter = EmbeddingsFilter(\n",
+    "    embeddings=embeddings_model, similarity_threshold=0.5\n",
+    ")\n",
+    "\n",
+    "re_ranker = LLMListwiseRerank.from_llm(llm, top_n=3)\n",
+    "\n",
+    "pipeline_compressor = DocumentCompressorPipeline(\n",
+    "    transformers=[redundant_filter, relevant_filter, re_ranker]\n",
+    ")\n",
+    "\n",
+    "llm_rerank_compression_retriever = ContextualCompressionRetriever(\n",
+    "    base_compressor=pipeline_compressor,\n",
+    "    base_retriever=multi_query_custom_retriever,\n",
+    ")"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/qa_testset.ipynb
+++ b/notebooks/qa_testset.ipynb
@@ -1225,6 +1225,58 @@
     "    base_retriever=multi_query_custom_retriever,\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54269cb1",
+   "metadata": {},
+   "source": [
+    "# 3. 검색기 성능 평가"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "366fb632",
+   "metadata": {},
+   "source": [
+    "## `(1) BM25, Similarity, Ensemble 평가지표 생성`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab6a7f66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from krag.utils import evaluate_retrieval_at_K\n",
+    "\n",
+    "retrievers = {\n",
+    "    'bm25': bm25_retriever,\n",
+    "    'similarity_score': similarity_retriever,\n",
+    "    'ensemble': ensemble_retriever,\n",
+    "}\n",
+    "\n",
+    "print(\"k:\", similarity_retriever.search_kwargs)\n",
+    "\n",
+    "df_evaluation, df_evaluation_data = evaluate_retrieval_at_K(\n",
+    "    df_qa_test, \n",
+    "    k=similarity_retriever.search_kwargs['k'],  \n",
+    "    retrievers=retrievers, \n",
+    "    ensemble=False, \n",
+    "    rouge_method='rouge2', \n",
+    "    threshold=0.8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0c63750",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_evaluation"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/qa_testset.ipynb
+++ b/notebooks/qa_testset.ipynb
@@ -1283,7 +1283,7 @@
    "id": "85fa896a",
    "metadata": {},
    "source": [
-    "## `(2) Multy Query, Multy Query Custom, Multi Query Decompostion 평가지표 생성`"
+    "## `(2) Multi Query, Multi Query Custom, Multi Query Decompostion 평가지표 생성`"
    ]
   },
   {
@@ -1297,8 +1297,8 @@
     "from krag.utils import evaluate_retrieval_at_K\n",
     "\n",
     "retrievers = {\n",
-    "    'multy_query' : multi_query_retriever,\n",
-    "    'multy_query_custom' : multi_query_custom_retriever,\n",
+    "    'multi_query' : multi_query_retriever,\n",
+    "    'multi_query_custom' : multi_query_custom_retriever,\n",
     "    'multi_query_decompostion' : multi_query_decompostion_retriever,\n",
     "}\n",
     "\n",

--- a/notebooks/qa_testset.ipynb
+++ b/notebooks/qa_testset.ipynb
@@ -1160,7 +1160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "3b4e5723",
    "metadata": {},
    "outputs": [],
@@ -1317,6 +1317,52 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d0a86578",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_evaluation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb3eb2dd",
+   "metadata": {},
+   "source": [
+    "## `(3) Cross Encoder Reranker, Embed Filter Compression, Compression Rerank, LLM-Rerank Retriever 평가지표 생성`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bfd5df94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 평가지표 계산\n",
+    "from krag.utils import evaluate_retrieval_at_K\n",
+    "\n",
+    "retrievers = {\n",
+    "    'cross_encoder_reranker' : cross_encoder_reranker_retriever,\n",
+    "    'embed_filter_compression' : embed_filter_compression_retriever,\n",
+    "    'compression_rerank' : pipeline_compression_retriever,\n",
+    "    'llm-rerank-retriever' : llm_rerank_compression_retriever,\n",
+    "}\n",
+    "\n",
+    "print(\"k:\", similarity_retriever.search_kwargs)\n",
+    "\n",
+    "df_evaluation, df_evaluation_data = evaluate_retrieval_at_K(\n",
+    "    df_qa_test, \n",
+    "    k=similarity_retriever.search_kwargs['k'],  \n",
+    "    retrievers=retrievers, \n",
+    "    ensemble=False, \n",
+    "    rouge_method='rouge2', \n",
+    "    threshold=0.8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db80859a",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #15 

## 📝 Description

- LLM 정의 및 벡터저장소 로드  
  - ollama exaone3.5 초기화  

- 기본 검색기  
  - BM25 리트리버 추가 KiwiTokenizer knlm 사용 
  - Similarity 리트리버 추가 

- 앙상블  
  - Ensemble 리트리버 구성 

- 멀티쿼리 계열  
  - Multi Query 리트리버 추가 LLM 기반 질의 확장  
  - Multi Query Custom 리트리버 추가 전용 프롬프트와 라인 리스트 파서 적용  
  - Multi Query Decomposition 리트리버 추가 서브 질문 다중 생성 체인

- 재정렬 및 맥락 압축  
  - Cross Encoder Reranker 리트리버 추가
  - Embed Filter Compression 리트리버 추가 
  - Compression Rerank 파이프라인 추가 중복 제거 관련성 필터 크로스 인코더 재정렬  
  - Compression LLM Rerank 파이프라인 추가 
