### PR TITLE
[ FEAT ] 검색기 평가지표 생성

### DIFF
--- a/notebooks/qa_testset.ipynb
+++ b/notebooks/qa_testset.ipynb
@@ -1277,6 +1277,51 @@
    "source": [
     "df_evaluation"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85fa896a",
+   "metadata": {},
+   "source": [
+    "## `(2) Multy Query, Multy Query Custom, Multi Query Decompostion 평가지표 생성`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "af9c8ace",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 평가지표 계산\n",
+    "from krag.utils import evaluate_retrieval_at_K\n",
+    "\n",
+    "retrievers = {\n",
+    "    'multy_query' : multi_query_retriever,\n",
+    "    'multy_query_custom' : multi_query_custom_retriever,\n",
+    "    'multi_query_decompostion' : multi_query_decompostion_retriever,\n",
+    "}\n",
+    "\n",
+    "print(\"k:\", similarity_retriever.search_kwargs)\n",
+    "\n",
+    "df_evaluation, df_evaluation_data = evaluate_retrieval_at_K(\n",
+    "    df_qa_test, \n",
+    "    k=similarity_retriever.search_kwargs['k'],  \n",
+    "    retrievers=retrievers, \n",
+    "    ensemble=False, \n",
+    "    rouge_method='rouge2', \n",
+    "    threshold=0.8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0a86578",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_evaluation"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/qa_testset.ipynb
+++ b/notebooks/qa_testset.ipynb
@@ -1225,6 +1225,58 @@
     "    base_retriever=multi_query_custom_retriever,\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54269cb1",
+   "metadata": {},
+   "source": [
+    "# 3. 검색기 성능 평가"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "366fb632",
+   "metadata": {},
+   "source": [
+    "## `(1) BM25, Similarity, Ensemble 평가지표 생성`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab6a7f66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from krag.utils import evaluate_retrieval_at_K\n",
+    "\n",
+    "retrievers = {\n",
+    "    'bm25': bm25_retriever,\n",
+    "    'similarity_score': similarity_retriever,\n",
+    "    'ensemble': ensemble_retriever,\n",
+    "}\n",
+    "\n",
+    "print(\"k:\", similarity_retriever.search_kwargs)\n",
+    "\n",
+    "df_evaluation, df_evaluation_data = evaluate_retrieval_at_K(\n",
+    "    df_qa_test, \n",
+    "    k=similarity_retriever.search_kwargs['k'],  \n",
+    "    retrievers=retrievers, \n",
+    "    ensemble=False, \n",
+    "    rouge_method='rouge2', \n",
+    "    threshold=0.8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0c63750",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_evaluation"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/qa_testset.ipynb
+++ b/notebooks/qa_testset.ipynb
@@ -1283,7 +1283,7 @@
    "id": "85fa896a",
    "metadata": {},
    "source": [
-    "## `(2) Multy Query, Multy Query Custom, Multi Query Decompostion 평가지표 생성`"
+    "## `(2) Multi Query, Multi Query Custom, Multi Query Decompostion 평가지표 생성`"
    ]
   },
   {
@@ -1297,8 +1297,8 @@
     "from krag.utils import evaluate_retrieval_at_K\n",
     "\n",
     "retrievers = {\n",
-    "    'multy_query' : multi_query_retriever,\n",
-    "    'multy_query_custom' : multi_query_custom_retriever,\n",
+    "    'multi_query' : multi_query_retriever,\n",
+    "    'multi_query_custom' : multi_query_custom_retriever,\n",
     "    'multi_query_decompostion' : multi_query_decompostion_retriever,\n",
     "}\n",
     "\n",

--- a/notebooks/qa_testset.ipynb
+++ b/notebooks/qa_testset.ipynb
@@ -1160,7 +1160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "3b4e5723",
    "metadata": {},
    "outputs": [],
@@ -1317,6 +1317,52 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d0a86578",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_evaluation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb3eb2dd",
+   "metadata": {},
+   "source": [
+    "## `(3) Cross Encoder Reranker, Embed Filter Compression, Compression Rerank, LLM-Rerank Retriever 평가지표 생성`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bfd5df94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 평가지표 계산\n",
+    "from krag.utils import evaluate_retrieval_at_K\n",
+    "\n",
+    "retrievers = {\n",
+    "    'cross_encoder_reranker' : cross_encoder_reranker_retriever,\n",
+    "    'embed_filter_compression' : embed_filter_compression_retriever,\n",
+    "    'compression_rerank' : pipeline_compression_retriever,\n",
+    "    'llm-rerank-retriever' : llm_rerank_compression_retriever,\n",
+    "}\n",
+    "\n",
+    "print(\"k:\", similarity_retriever.search_kwargs)\n",
+    "\n",
+    "df_evaluation, df_evaluation_data = evaluate_retrieval_at_K(\n",
+    "    df_qa_test, \n",
+    "    k=similarity_retriever.search_kwargs['k'],  \n",
+    "    retrievers=retrievers, \n",
+    "    ensemble=False, \n",
+    "    rouge_method='rouge2', \n",
+    "    threshold=0.8)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db80859a",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #15 

## 📝 Description

- 평가 루틴 구성
  - `krag.evaluate_retrieval_at_K` 적용
  - 공통 설정: `rouge_method='rouge2'`, `threshold=0.8`
  - `k` 값은 각 리트리버의 `search_kwargs['k']`에서 참조하도록 일관화
  - 결과 데이터프레임 `df_evaluation`, `df_evaluation_data` 수집

- 대상 리트리버 세트
  - 기본 계열: **BM25**, **Similarity**, **Ensemble**
  - 멀티쿼리 계열: **Multi Query**, **Multi Query Custom**, **Multi Query Decomposition**
  - 재정렬 및 압축 계열: **Cross Encoder Reranker**, **Embeddings Filter Compression**, **Compression Rerank**, **LLM-Listwise Rerank**

- 산출물

| retriever                 | hit_rate@8 | mrr@8   | micro_recall@8 | macro_recall@8 | micro_precision@8 | macro_precision@8 | micro_f1@8 | macro_f1@8 | map@8   | ndcg@8   |
|---------------------------|------------|---------|----------------|----------------|-------------------|-------------------|------------|------------|---------|----------|
| bm25                      | 0.947368   | 0.521387| 0.947368       | 0.947368       | 0.118421          | 0.118421          | 0.222222   | 0.222222   | 0.521387| 0.697774 |
| ensemble                  | 1.000000   | 0.771512| 1.000000       | 1.000000       | 0.125000          | 0.125000          | 0.222222   | 0.222222   | 0.771512| 0.841792 |
| similarity_score          | 1.000000   | 0.820760| 1.000000       | 1.000000       | 0.125000          | 0.125000          | 0.222222   | 0.222222   | 0.820760| 0.876725 |
| multi_query_decompostion  | 1.000000   | 0.709378| 1.000000       | 1.000000       | 0.125000          | 0.125000          | 0.222222   | 0.222222   | 0.709378| 0.801399 |
| multi_query               | 0.982456   | 0.741541| 0.982456       | 0.982456       | 0.122807          | 0.122807          | 0.222222   | 0.222222   | 0.741541| 0.834836 |
| multi_query_custom        | 1.000000   | 0.797953| 1.000000       | 1.000000       | 0.125000          | 0.125000          | 0.222222   | 0.222222   | 0.797953| 0.856466 |
| cross_encoder_reranker    | 1.000000   | 0.859649| 1.000000       | 1.000000       | 0.333333          | 0.333333          | 0.500000   | 0.500000   | 0.859649| 0.920717 |
| embed_filter_compression  | 0.929825   | 0.812865| 0.929825       | 0.929825       | 0.394737          | 0.394737          | 0.578616   | 0.578616   | 0.812865| 0.875420 |
| compression_rerank      | 0.929825   | 0.818713| 0.929825       | 0.929825       | 0.359649          | 0.359649          | 0.544025   | 0.544025   | 0.818713| 0.905014 |
| llm-rerank-retriever | 0.732143   | 0.508929| 0.732143       | 0.732143       | 0.369048          | 0.369048          | 0.642276   | 0.642276   | 0.508929| 0.786898 |

- `cross_encoder_reranker` 가 최상위 랭킹 품질을(→ `MRR 0.8596` / `NDCG 0.9207`) 기록했습니다.
- 맥락 압축 파이프라인은 정밀도·F1을 크게 올리지만 `Hit Rate(=recall)` 하락이 동반되는 것을 확인할 수 있습니다.
- 멀티 쿼리 계열 파이프라인은 랭킹지표가 비교적 낮아지는 경향을 확인할 수 있습니다.
- `BM25` 는 정답 포함 가능성과 랭킹지표가 모두 낮은 것을 확인할 수 있고, `Ensemble` 은 BM25 단독 대비 개선된 것을 확인할 수 있지만, `Similarity Score` 에는 미치지 못하는 것을 볼 수 있습니다.