### PR TITLE
[ FEAT ] 멀티쿼리 + Cross-Encoder 리랭커 기반 RAG 리트리버 전환

### DIFF
--- a/app/containers/domain.py
+++ b/app/containers/domain.py
@@ -42,6 +42,7 @@ class DomainsContainer(containers.DeclarativeContainer):
         build_rag_chain,
         vectorstore=infra.chroma,
         llm=infra.llm,
+        re_ranker=infra.re_ranker
     )
 
     # Reids-Stream

--- a/app/containers/infra.py
+++ b/app/containers/infra.py
@@ -1,4 +1,6 @@
 from dependency_injector import containers, providers
+from langchain.retrievers.document_compressors import CrossEncoderReranker
+from langchain_community.cross_encoders import HuggingFaceCrossEncoder
 from redis.asyncio import Redis
 from app.core.config import settings
 from app.database.session import AsyncScopedSession
@@ -20,8 +22,8 @@ class InfraContainer(containers.DeclarativeContainer):
     # Redis
     redis = providers.Singleton(
         Redis.from_url,
-        url = config.provided.REDIS_URL,
-        decode_responses=True
+        url=config.provided.REDIS_URL,
+        decode_responses=True,
     )
 
     stream_name = providers.Object(settings.REDIS_STREAM_NAME)
@@ -66,5 +68,16 @@ class InfraContainer(containers.DeclarativeContainer):
     llm = providers.Singleton(
         ChatOllama,
         model="exaone3.5",
-        temperature=0.3,
+        temperature=0.5,
+    )
+
+    encoder = providers.Singleton(
+        HuggingFaceCrossEncoder,
+        model_name="BAAI/bge-reranker-v2-m3",
+    )
+
+    re_ranker = providers.Singleton(
+        CrossEncoderReranker,
+        model=encoder,
+        top_n=3,
     )

--- a/app/rag/chain.py
+++ b/app/rag/chain.py
@@ -1,12 +1,14 @@
 from typing import List
+
 from langchain_core.documents import Document
 from langchain_core.runnables import RunnablePassthrough, RunnableLambda
-from langchain_core.output_parsers import StrOutputParser
-from langchain_core.prompts import ChatPromptTemplate
-from langchain.retrievers import EnsembleRetriever
-from langchain_community.retrievers import BM25Retriever
+from langchain_core.output_parsers import StrOutputParser, BaseOutputParser
+from langchain_core.prompts import ChatPromptTemplate, PromptTemplate
 from langchain_chroma import Chroma
 from langchain_ollama import ChatOllama
+from langchain.retrievers.document_compressors import CrossEncoderReranker
+from langchain.retrievers import ContextualCompressionRetriever
+from langchain.retrievers.multi_query import MultiQueryRetriever
 
 
 PROMPT_TEMPLATE = """
@@ -23,39 +25,70 @@ If the answer is not in the context, answer "잘 모르겠습니다.".
 [Answer]
 """.strip()
 
-def _format_docs(docs: List[Document]) -> str:
+MULTI_QUERY_PROMPT = PromptTemplate(
+    input_variables=["question"],
+    template="""Generate three different versions of the given user question to retrieve relevant documents from a vector database. The goal is to reframe the question from various perspectives to overcome limitations of distance-based similarity search.
+
+    The generated questions should have the following characteristics:
+    1. Maintain the core intent of the original question but use different expressions or viewpoints.
+    2. Include synonyms or related concepts where possible.
+    3. Slightly broaden or narrow the scope of the question to potentially include diverse relevant information.
+
+    Write each question on a new line and include only the questions.
+
+    [Original question]
+    {question}
+    
+    [Alternative questions]
+    """,
+)
+
+
+class LineListOutputParser(BaseOutputParser[List[str]]):
+    """Output parser for a list of lines."""
+
+    def parse(self, text: str) -> List[str]:
+        """Split the text into lines and remove empty lines."""
+        return [line.strip() for line in text.strip().split("\n") if line.strip()]
+
+
+def build_chroma_retriever(
+    vectorstore: Chroma, k: int = 5, score_threshold: float = 0.5
+):
+    return vectorstore.as_retriever(
+        search_type="similarity_score_threshold",
+        search_kwargs={"score_threshold": score_threshold, "k": k},
+    )
+
+
+def build_multi_query_custom_retriever(vectorstore: Chroma, llm: ChatOllama):
+    return MultiQueryRetriever(
+        retriever=build_chroma_retriever(vectorstore),
+        llm_chain=MULTI_QUERY_PROMPT | llm | LineListOutputParser(),
+        parser_key="lines",
+    )
+
+
+def build_cross_encoder_rerank_retriever(
+    vectorstore: Chroma, llm: ChatOllama, re_ranker: CrossEncoderReranker
+):
+    return ContextualCompressionRetriever(
+        base_compressor=re_ranker,
+        base_retriever=build_multi_query_custom_retriever(vectorstore, llm),
+    )
+
+
+def format_docs(docs: List[Document]) -> str:
     return "\n\n".join(d.page_content for d in docs)
 
-def build_bm25_retriever(vectorstore: Chroma) -> BM25Retriever:
-    col = vectorstore._collection  # 내부 핸들 (버전 따라 바뀔 수 있음)
-    raw = col.get(include=["documents", "metadatas"])
-    docs = [
-        Document(page_content=txt, metadata=meta)
-        for txt, meta in zip(raw.get("documents", []), raw.get("metadatas", []))
-        if txt
-    ]
-    bm25 = BM25Retriever.from_documents(docs)
-    return bm25
 
-def build_ensemble_retriever(vectorstore: Chroma) -> EnsembleRetriever:
-    chroma_threshold = vectorstore.as_retriever(
-        search_type="similarity_score_threshold",
-        search_kwargs={"score_threshold": 0.5, "k": 2},
-    )
-
-    bm25 = build_bm25_retriever(vectorstore)
-
-    return EnsembleRetriever(
-        retrievers=[chroma_threshold, bm25],
-        weights=[0.5, 0.5],
-        search_kwargs={"k": 2},
-    )
-
-def build_rag_chain(vectorstore: Chroma, llm: ChatOllama):
+def build_rag_chain(
+    vectorstore: Chroma, llm: ChatOllama, re_ranker: CrossEncoderReranker
+):
     prompt = ChatPromptTemplate.from_template(PROMPT_TEMPLATE)
-    retriever = build_ensemble_retriever(vectorstore)
+    retriever = build_cross_encoder_rerank_retriever(vectorstore, llm, re_ranker)
 
-    retriever_chain = retriever | RunnableLambda(_format_docs)
+    retriever_chain = retriever | RunnableLambda(format_docs)
 
     chain = (
         {"context": retriever_chain, "question": RunnablePassthrough()}
@@ -63,4 +96,5 @@ def build_rag_chain(vectorstore: Chroma, llm: ChatOllama):
         | llm
         | StrOutputParser()
     )
+
     return chain


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #19 

## 📝 Description

- 기존 **BM25 + 벡터 하이브리드(앙상블)** 리트리버를 제거하고 **멀티쿼리 + Cross-Encoder 리랭커** 구조로 변경했습니다.
- 리랭커 추가: CrossEncoderReranker(model=encoder, top_n=3)
- 멀티쿼리 리트리버: MultiQueryRetriever
  - 프롬프트 MULTI_QUERY_PROMPT로 질문을 3변형 생성 

### 주요 코드
```python
# DI (infra.py)
encoder = providers.Singleton(
    HuggingFaceCrossEncoder,
    model_name="BAAI/bge-reranker-v2-m3",
)
re_ranker = providers.Singleton(
    CrossEncoderReranker,
    model=encoder,
    top_n=3,
)

# Retriever 구성
def build_chroma_retriever(vs: Chroma, k: int = 5, score_threshold: float = 0.5):
    return vs.as_retriever(
        search_type="similarity_score_threshold",
        search_kwargs={"score_threshold": score_threshold, "k": k},
    )

def build_multi_query_custom_retriever(vs: Chroma, llm: ChatOllama):
    return MultiQueryRetriever(
        retriever=build_chroma_retriever(vs),
        llm_chain=MULTI_QUERY_PROMPT | llm | LineListOutputParser(),
        parser_key="lines",
    )

def build_cross_encoder_rerank_retriever(vs: Chroma, llm: ChatOllama, re_ranker):
    return ContextualCompressionRetriever(
        base_compressor=re_ranker,
        base_retriever=build_multi_query_custom_retriever(vs, llm),
    )
```
